### PR TITLE
Revert "Error handling improvements"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 This package is a lightweight wrapper for the Svea Ekonomi Payment Gateway API ([docs](https://www.svea.com/globalassets/sweden/foretag/betallosningar/e-handel/moduler-integration/payment_gateway_api_eng.2.8.8.pdf)) for Go. It provides easy to use functions/methods and error templates with most of the API implemented.
 
 ## Prerequisites
-
 * Merchant ID
 * Secret "word"
 
 These can be obtained by signing an agreement with Svea Ekonomi to use their payment services.
 
 ## Important to note
-
 Requests to the Svea Payment Gateway API result in a status code. The functions and methods in this package return errors corresponding to these status codes if the status code is anything other than `0` (success!). The cause of these errors can be determined programmatically by using the error "template" variables this package provides. The names of these all begin with `Err` (for example `ErrInternalError` or `ErrDeniedByBank`).
 
 One of these errors stand out though. Some requests to the Svea Payment Gateway API can result in the status code `1`, which means the request was successful but a manual review is in order for the merchant. This error is `ErrRequiresManualReview`. Remember this!
@@ -16,9 +14,7 @@ One of these errors stand out though. Some requests to the Svea Payment Gateway 
 The Svea Payment Gateway API expects the order amount to be represented in the smallest form of a given currency. Please note that [in this example](#recur-payment), an amount of 100 and a currency of SEK would result in 1 kr being charged, **not** 100.
 
 ## Creating a client
-
 The first step of using this package is to create a client with the [above mentioned credentials](#prerequisites), this client will be used to make requests to the API.
-
 ```go
 c := sveawebpay.NewClient(merchantID, secret)
 
@@ -27,7 +23,6 @@ c.Test = true
 ```
 
 ## Prepare payment
-
 ```go
 //Create order
 order := sveawebpay.Order{
@@ -63,26 +58,22 @@ order.AddRow(
 )
 
 //Prepare the payment
-response, err := c.PreparePayment(order)
+preparedPayment, err := c.PreparePayment(order)
 if err != nil {
   //Handle error..
 }
 
 //Get the url to where the payment can be completed
-url := response.PreparedPayment.URL()
+url := preparedPayment.URL()
 ```
 
 ## Prepared payment callback (decode payment response)
-
 ```go
-paymentResponse, err := c.DecodePaymentResponseBody(r)
-transaction := paymentResponse.Transaction
+transaction, err := c.DecodePaymentResponseBody(r)
 ```
 
 ## Recur payment
-
 Create a new transaction for an existing subscription. A subscription can be created by [preparing a payment](#prepare-payment).
-
 ```go
 order := sveawebpay.RecurOrder{
     CustomerRefNo: "order id",
@@ -92,56 +83,43 @@ order := sveawebpay.RecurOrder{
     Vat: 25,
 }
 
-paymentResponse, err := c.Recur(order)
-transaction := paymentResponse.Transaction
+transaction, err := c.Recur(order)
 ```
 
 ## Cancel a recur subscription
-
 Cancel an existing recur subscription so that no further recurs can be made on it.
-
 ```go
-response, err := c.CancelRecurSubscription(subscriptionID)
+err := c.CancelRecurSubscription(subscriptionID)
 ```
 
 ## Credit a transaction
-
 Credit a transaction and return money to the customer. Only transactions that have reached the status SUCCESS can be credited.
-
 ```go
 err := c.Credit(transactionID, amount)
 ```
 
 ## Annul a transaction
-
 Cancel a payment before it has been captured. It can only be performed on card, invoice, or payment plan transactions having the status AUTHORIZED or CONFIRMED.
-
 ```go
 err := c.Annul(transactionID)
 ```
 
 ## Confirm a transaction
-
 Confirm a transaction. It is intended for card transactions. It can only be performed on card transactions having the status AUTHORIZED. This will result in a CONFIRMED transaction that will be captured (settled) on the given capture date. Confirm is mainly used by merchants who are configured to confirm their transactions themselves. Otherwise the transactions are confirmed automatically.
-
 ```go
 err := c.Annul(transactionID, time.Now())
 ```
 
 ## Lower the amount to be captured on a transaction
-
 Lower the amount to be captured on a transaction before it has been captured. It is intended for card transactions having the status AUTHORIZED or CONFIRMED. It can be used e.g. if the merchant is unable to deliver all of the items that was ordered by the customer, and wants to lower the total amount to pay. If the `amountToLower` is equal to the authorized amount, the transaction status will change to annulled.
-
 ```go
 err := c.LowerAmount(transactionID, amountToLower)
 ```
 
 ## Get information about a transaction
-
 Get information about a specific order with either the specified transaction ID or customer reference number. Both does not need to be provided. If `transactionID` is less than or equal to `0`, `customerRefNo` will be used. If `customerRefNo` is an empty string as well a package error will be returned. If both are set `transactionID` will be used.
 
 **Please only use this when needed. Repetitive polling is not allowed.**
-
 ```go
 transaction, err := c.GetTransaction(transactionID, customerRefNo)
 ```

--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// TestClientPreparePayment tests the `Client` method `PreparePayment`
+//TestClientPreparePayment tests the `Client` method `PreparePayment`
 func TestClientPreparePayment(t *testing.T) {
 	//Load .env file
 	if err := godotenv.Load(); err != nil {
@@ -52,14 +52,13 @@ func TestClientPreparePayment(t *testing.T) {
 	)
 
 	//Prepare the payment
-	response, err := c.PreparePayment(order)
+	preparedPayment, err := c.PreparePayment(order)
 	if err != nil && ErrToCode(err) < 0 {
 		t.Error(err)
 		return
 	}
 
-	t.Logf("PreparedPayment: %v", response.PreparedPayment)
-	t.Logf("URL: %v", response.PreparedPayment.URL())
-	t.Logf("Statuscode response: %v", response.StatusCode)
-	t.Logf("Statuscode ErrToCode: %v", ErrToCode(err))
+	t.Logf("PreparedPayment: %v", preparedPayment)
+	t.Logf("URL: %v", preparedPayment.URL())
+	t.Logf("Statuscode: %v", ErrToCode(err))
 }

--- a/errors.go
+++ b/errors.go
@@ -1,12 +1,9 @@
 package sveawebpay
 
-import (
-	"errors"
-	"fmt"
-)
+import "errors"
 
-// ErrToCode returns the status code that corresponds to the specified error. The
-// error must be one of the constants specified by this package or `-1` will be returned
+//ErrToCode returns the status code that corresponds to the specified error. The
+//error must be one of the constants specified by this package or `-1` will be returned
 func ErrToCode(err error) int {
 	for c, e := range errMap {
 		if err == e {
@@ -17,25 +14,23 @@ func ErrToCode(err error) int {
 	return -1
 }
 
-// CodeToErr returns the error that corresponds to the specified status code. The
-// status code must be one returned by the svea api or "unknown error: <code>" will be returned
+//CodeToErr returns the error that corresponds to the specified status code. The
+//status code must be one returned by the svea api or `ErrUnknown` will be returned
 func CodeToErr(code int) error {
-	if code == 0 {
-		return nil
+	for c, e := range errMap {
+		if code == c {
+			return e
+		}
 	}
 
-	if e, ok := errMap[code]; ok {
-		return e
-	}
-
-	return fmt.Errorf("unknown error: %d", code)
+	return ErrUnknown
 }
 
-// ErrRequiresManualReview should not be handled like any other error, the
-// request was successful but still for some reason needs to be reviewed manually
+//ErrRequiresManualReview should not be handled like any other error, the
+//request was successful but still for some reason needs to be reviewed manually
 var ErrRequiresManualReview = errors.New("request performed successfully but requires manual review by merchant")
 
-// Possible errors returned by the svea api
+//Possible errors returned by the svea api
 var (
 	ErrInternalError                             = errors.New("internal system error")
 	ErrXMLParseFail                              = errors.New("invalid XML")
@@ -77,7 +72,6 @@ var (
 	ErrBrowserNotSupported                       = errors.New("the browser version is too old")
 	ErrPending                                   = errors.New("the request is still being processed")
 	ErrCreditPending                             = errors.New("the credit could not be handled instantly. It is put in a queue and it will be processed in due time")
-	ErrCardClosed                                = errors.New("card is closed")
 	ErrBadTransactionID                          = errors.New("invalid transaction ID")
 	ErrBadMerchantID                             = errors.New("invalid merchant ID")
 	ErrBadLang                                   = errors.New("invalid language")
@@ -118,7 +112,6 @@ var (
 	ErrBadOrderRow                               = errors.New("invalid format for Order Row")
 	ErrBadPayerAlias                             = errors.New("invalid format for Payer AliasPhone number")
 	ErrBadShowStoreCardDialog                    = errors.New("invalid value for Show Store Card Dialog")
-	ErrServiceUnavailableTryLater                = errors.New("temporary problem, try later")
 	ErrAntiFraudCardBinNotAllowed                = errors.New("antifraud - cardbin not allowed")
 	ErrAntiFraudIPLocationNotAllowed             = errors.New("antifraud – iplocation not allowed")
 	ErrAntiFraudIPLocationAndBinDoesntMatch      = errors.New("antifraud – ip-location and bin does not match")
@@ -132,9 +125,10 @@ var (
 	ErrSwishRefundPayerError                     = errors.New("payer alias in the refund does not match the payee alias in the original payment")
 	ErrSwishRefundPayerOrgNrError                = errors.New("payer organization number do not match original payment payee organization number")
 	ErrSwishRefundPayeeSSNError                  = errors.New("the Payer SSN in the original payment is not the same as the SSN for the current Payee")
+	ErrUnknown                                   = errors.New("unknown error")
 )
 
-// Map status codes to errors
+//Map status codes to errors
 var errMap = map[int]error{
 	1:   ErrRequiresManualReview,
 	100: ErrInternalError,
@@ -177,7 +171,6 @@ var errMap = map[int]error{
 	148: ErrBrowserNotSupported,
 	149: ErrPending,
 	150: ErrCreditPending,
-	152: ErrCardClosed,
 	301: ErrBadTransactionID,
 	303: ErrBadMerchantID,
 	304: ErrBadLang,
@@ -218,7 +211,6 @@ var errMap = map[int]error{
 	345: ErrBadOrderRow,
 	346: ErrBadPayerAlias,
 	347: ErrBadShowStoreCardDialog,
-	373: ErrServiceUnavailableTryLater,
 	500: ErrAntiFraudCardBinNotAllowed,
 	501: ErrAntiFraudIPLocationNotAllowed,
 	502: ErrAntiFraudIPLocationAndBinDoesntMatch,

--- a/response.go
+++ b/response.go
@@ -1,24 +1,24 @@
 package sveawebpay
 
-type ResponseBody struct {
+type responseBody struct {
 	Message string `xml:"message"`
 }
 
-type Response struct {
+type response struct {
 	StatusCode int `xml:"statuscode"`
 }
 
-type PreparedPaymentResponse struct {
+type preparedPaymentResponse struct {
 	PreparedPayment PreparedPayment `xml:"preparedpayment"`
-	Response
+	response
 }
 
-type PaymentResponse struct {
+type paymentResponse struct {
 	Transaction Transaction `xml:"transaction"`
-	Response
+	response
 }
 
-type CardTransaction struct {
+type cardTransaction struct {
 	CardType     string `xml:"cardtype"`
 	MaskedCardNo string `xml:"maskedcardno"`
 	ExpiryMonth  string `xml:"expirymonth"`
@@ -26,7 +26,7 @@ type CardTransaction struct {
 	AuthCode     string `xml:"authcode"`
 }
 
-// Transaction represents a transaction received in the response message from the svea api
+//Transaction represents a transaction receieved in the response message from the svea api
 type Transaction struct {
 	PaymentMethod    string `xml:"paymentmethod"`
 	CustomerRefNo    string `xml:"customerrefno"`
@@ -35,5 +35,5 @@ type Transaction struct {
 	SubscriptionID   int    `xml:"subscriptionid"`
 	SubscriptionType string `xml:"subscriptiontype"`
 	ID               string `xml:"id,attr"`
-	CardTransaction
+	cardTransaction
 }


### PR DESCRIPTION
Reverts MjukBiltvatt/go-sveawebpay#5. Since #5 includes breaking changes they should not have been merged into main, but instead stayed in a `v2` branch (see the [official documentation for major versions](https://go.dev/doc/modules/major-version)).

Diff between this PR and before #5: https://github.com/MjukBiltvatt/go-sveawebpay/compare/618ce244c5e3fd085332732edb8f9bfea8dc6575...368505907e023eb3d1c6a4dc756edc9a2b18777c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Payment processing method return types have been updated.
  * Several previously public type definitions are now private.
  * Two error codes have been removed from the error handling API.

* **New Features**
  * Added new error type for unknown error conditions.
  * Payment transaction objects now include amount and currency information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->